### PR TITLE
Add base64 encoder app

### DIFF
--- a/components/locations/Field.tsx
+++ b/components/locations/Field.tsx
@@ -47,8 +47,11 @@ const Field = () => {
         const base64Url = `data:image/png;base64,${base64Image}`.trim();
         sdk.entry.fields.base64Image.setValue(base64Url);
         setBase64(base64Url);
-        setIsLoading(false);
-      });
+      })
+      .catch((error) => {
+        console.error(error);
+      })
+      .finally(() => setIsLoading(false));
   }, [sdk.entry.fields.base64Image, sdk.entry.fields.image, cma.asset]);
 
   if (isLoading) {

--- a/components/locations/Field.tsx
+++ b/components/locations/Field.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Paragraph } from '@contentful/f36-components';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Spinner, TextInput } from '@contentful/f36-components';
 import { FieldAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { createClient } from 'contentful-management';
@@ -8,21 +8,32 @@ import nextBase64 from 'next-base64';
 const Field = () => {
   const sdk = useSDK<FieldAppSDK>();
   const [base64, setBase64] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
 
-  const cma = createClient(
-    { apiAdapter: sdk.cmaAdapter },
-    {
-      type: 'plain',
-      defaults: {
-        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
-        spaceId: sdk.ids.space,
-      },
-    }
+  const cma = useMemo(
+    () =>
+      createClient(
+        { apiAdapter: sdk.cmaAdapter },
+        {
+          type: 'plain',
+          defaults: {
+            environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
+            spaceId: sdk.ids.space,
+          },
+        }
+      ),
+    [
+      sdk.cmaAdapter,
+      sdk.ids.environmentAlias,
+      sdk.ids.environment,
+      sdk.ids.space,
+    ]
   );
 
-  useEffect(() => {
-    sdk.window.startAutoResizer();
+  useEffect(() => sdk.window.startAutoResizer(), [sdk.window]);
 
+  useEffect(() => {
+    setIsLoading(true);
     const image = sdk.entry.fields.image.getValue();
 
     cma.asset
@@ -34,17 +45,17 @@ const Field = () => {
         const imageUrl = `https:${url}`.trim();
         const base64Image = nextBase64.encode(imageUrl);
         const base64Url = `data:image/png;base64,${base64Image}`.trim();
+        sdk.entry.fields.base64Image.setValue(base64Url);
         setBase64(base64Url);
+        setIsLoading(false);
       });
-  }, [sdk, cma]);
+  }, [sdk.entry.fields.base64Image, sdk.entry.fields.image, cma.asset]);
 
-  console.log(base64);
+  if (isLoading) {
+    return <Spinner />;
+  }
 
-  return (
-    <div>
-      <Paragraph>{base64}</Paragraph>
-    </div>
-  );
+  return <TextInput name='base64Image' value={base64} isReadOnly />;
 };
 
 export default Field;

--- a/components/locations/Field.tsx
+++ b/components/locations/Field.tsx
@@ -1,19 +1,50 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { FieldAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { createClient } from 'contentful-management';
+import nextBase64 from 'next-base64';
 
 const Field = () => {
   const sdk = useSDK<FieldAppSDK>();
-  /*
-     To use the cma, inject it as follows
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
-  // If you only want to extend Contentful's default editing experience
-  // reuse Contentful's editor components
-  // -> https://www.contentful.com/developers/docs/extensibility/field-editors/
-  return <Paragraph>Hello Entry Field Component (AppId: {sdk.ids.app})</Paragraph>;
+  const [base64, setBase64] = useState('');
+
+  const cma = createClient(
+    { apiAdapter: sdk.cmaAdapter },
+    {
+      type: 'plain',
+      defaults: {
+        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
+        spaceId: sdk.ids.space,
+      },
+    }
+  );
+
+  useEffect(() => {
+    sdk.window.startAutoResizer();
+
+    const image = sdk.entry.fields.image.getValue();
+
+    cma.asset
+      .get({
+        assetId: image.sys.id,
+      })
+      .then((data) => {
+        const url = data.fields.file['en-US'].url;
+        const imageUrl = `https:${url}`.trim();
+        const base64Image = nextBase64.encode(imageUrl);
+        const base64Url = `data:image/png;base64,${base64Image}`.trim();
+        setBase64(base64Url);
+      });
+  }, [sdk, cma]);
+
+  console.log(base64);
+
+  return (
+    <div>
+      <Paragraph>{base64}</Paragraph>
+    </div>
+  );
 };
 
 export default Field;

--- a/components/locations/Field.tsx
+++ b/components/locations/Field.tsx
@@ -33,25 +33,26 @@ const Field = () => {
   useEffect(() => sdk.window.startAutoResizer(), [sdk.window]);
 
   useEffect(() => {
-    setIsLoading(true);
-    const image = sdk.entry.fields.image.getValue();
-
-    cma.asset
-      .get({
-        assetId: image.sys.id,
-      })
-      .then((data) => {
+    const fetchImage = async () => {
+      try {
+        setIsLoading(true);
+        const image = sdk.entry.fields.image.getValue();
+        const data = await cma.asset.get({
+          assetId: image.sys.id,
+        });
         const url = data.fields.file['en-US'].url;
         const imageUrl = `https:${url}`.trim();
         const base64Image = nextBase64.encode(imageUrl);
         const base64Url = `data:image/png;base64,${base64Image}`.trim();
         sdk.entry.fields.base64Image.setValue(base64Url);
         setBase64(base64Url);
-      })
-      .catch((error) => {
+      } catch (error) {
         console.error(error);
-      })
-      .finally(() => setIsLoading(false));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchImage();
   }, [sdk.entry.fields.base64Image, sdk.entry.fields.image, cma.asset]);
 
   if (isLoading) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/react-apps-toolkit": "1.2.16",
         "next": "13.4.8",
+        "next-base64": "^1.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -7760,6 +7761,14 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-base64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-base64/-/next-base64-1.1.0.tgz",
+      "integrity": "sha512-roPubI4go4Cnb8oBp3OcXWoNmzDiMv8ykBfFe02c5imGuZJlXMBXfr6vc9gpr0rvImtgvL1FcQCZAvI/ZESVgg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/next/node_modules/@swc/helpers": {
@@ -15761,6 +15770,11 @@
           }
         }
       }
+    },
+    "next-base64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-base64/-/next-base64-1.1.0.tgz",
+      "integrity": "sha512-roPubI4go4Cnb8oBp3OcXWoNmzDiMv8ykBfFe02c5imGuZJlXMBXfr6vc9gpr0rvImtgvL1FcQCZAvI/ZESVgg=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@contentful/f36-tokens": "4.0.2",
     "@contentful/react-apps-toolkit": "1.2.16",
     "next": "13.4.8",
+    "next-base64": "^1.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
## Description
This project built with the Contentful App Framework enhances a Contentful's Field component to receive a `base64` string of the post's image. The post's image `url` will be used to generate a base64 string and then concatenated with other strings that comply with `Next.js Image` prop `blurDataURL` format, to be finally saved into the post's data and injected into the component's UI with an input field.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Tests (Adding missing tests or correcting existing tests)
- [x] Styles (Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))

## Screenshots and links
![image](https://github.com/mikemtzp/base64-encoder/assets/97407840/0251d5f2-cba1-4752-af08-5d3c2a7c39f5)
